### PR TITLE
Fix return type annotation for iterate

### DIFF
--- a/src/utils/buffer.py
+++ b/src/utils/buffer.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections import deque
-from typing import AsyncGenerator, Deque, Iterable, List
+from typing import AsyncGenerator, Deque, List
 
 from ..feature_extraction.mfcc import extract_mfcc
 from ..filter.denoise import denoise
@@ -20,7 +20,7 @@ class AdaptiveBuffer:
         self.queue.append(chunk)
         self.event.set()
 
-    async def iterate(self) -> Iterable[bytes]:
+    async def iterate(self) -> AsyncGenerator[bytes, None]:
         while True:
             if not self.queue:
                 self.event.clear()


### PR DESCRIPTION
## Summary
- annotate `iterate` in `AdaptiveBuffer` as an `AsyncGenerator`

## Testing
- `mypy src`
- `flake8` *(fails: F401, E501, etc.)*
- `pytest -q` *(fails: ImportError collecting tests/test_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68540b6b90408331935a610238ced9b2