### PR TITLE
Use BuildConfig for network base URL

### DIFF
--- a/ClockworkRed/data/build.gradle.kts
+++ b/ClockworkRed/data/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     defaultConfig {
         minSdk = 24
         targetSdk = 34
+        buildConfigField("String", "BASE_URL", "\"https://api.clockworkred.com/\"")
     }
 }
 

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/DataModule.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/DataModule.kt
@@ -5,6 +5,7 @@ import com.clockworkred.domain.AiRepository
 import com.clockworkred.data.remote.AiService
 import com.clockworkred.data.remote.ApiKeyInterceptor
 import com.clockworkred.data.repository.AiRepositoryImpl
+import com.clockworkred.data.BuildConfig
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -14,6 +15,8 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.first
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -27,11 +30,9 @@ abstract class DataModule {
         @Provides
         @Singleton
         fun provideOkHttpClient(settings: SettingsRepository): OkHttpClient {
+            val apiKey = runBlocking { settings.getApiKey().first() } ?: ""
             return OkHttpClient.Builder()
-                .addInterceptor(ApiKeyInterceptor { 
-                    // TODO read API key from SettingsRepository synchronously
-                    "" 
-                })
+                .addInterceptor(ApiKeyInterceptor { apiKey })
                 .build()
         }
 
@@ -39,8 +40,7 @@ abstract class DataModule {
         @Singleton
         fun provideAiService(client: OkHttpClient): AiService {
             return Retrofit.Builder()
-                // TODO replace with real base URL
-                .baseUrl("https://example.com")
+                .baseUrl(BuildConfig.BASE_URL)
                 .client(client)
                 .addConverterFactory(MoshiConverterFactory.create())
                 .build()

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ comments in the workflow and code for references.
    ./gradlew installDebug
    ```
 
+   Network requests use the `BASE_URL` value from
+   `ClockworkRed/data/build.gradle.kts`. Edit this property to point the
+   Android client at your backend service.
+
 ## WebSocket Streaming
 The `/ws` endpoint allows streaming audio for realtime chord suggestions.
 Send JSON messages with a `data` field containing raw or base64-encoded audio


### PR DESCRIPTION
## Summary
- fetch API key synchronously in `DataModule`
- use `BuildConfig.BASE_URL` instead of a placeholder value
- document updating the base URL for Android builds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685412be6978833192b5a9c5ef10ba67